### PR TITLE
Fix npm install failure caused by missing vite-pwa asset generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",
-    "vite-plugin-pwa": "^0.20.0"
+    "vite-plugin-pwa": "^0.19.8"
   }
 }


### PR DESCRIPTION
## Summary
- downgrade vite-plugin-pwa to ^0.19.8 so npm no longer requests the unpublished @vite-pwa/assets-generator@^0.17.5 release

## Testing
- npm install *(fails in the sandbox: 403 Forbidden when reaching registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc234899c8320801720916b6c11e3